### PR TITLE
Add aws.s3 and aws.ec2metadata to default package list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y -t unstable \
     wget --no-verbose "https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/shiny-server-${SHINY_SERVER_VERSION}-amd64.deb" -O shinystudio.deb && \
     gdebi -n shinystudio.deb && \
     rm -f shinystudio.deb && \
-    R -e "install.packages(c('shiny', 'rmarkdown', 'tidyverse', 'magrittr', 'lubridate', 'plotly', 'shinydashboard', 'DT', 'dplyr'), repos='https://cran.rstudio.com/')" && \
+    R -e "install.packages(c('shiny', 'rmarkdown', 'tidyverse', 'magrittr', 'lubridate', 'plotly', 'shinydashboard', 'DT', 'dplyr', 'aws.s3', 'aws.ec2metadata'), repos='https://cran.rstudio.com/')" && \
     cp -R /usr/local/lib/R/site-library/shiny/examples/* /srv/shiny-server/ && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /var/log/shiny-server && \


### PR DESCRIPTION
Pushed to docker hub as `neighborhoods/shiny-server:r3.4.3-shiny1.5.6-2`